### PR TITLE
Extend document model with embedded_claim_url and provide use-case example

### DIFF
--- a/eversign/document.py
+++ b/eversign/document.py
@@ -168,6 +168,7 @@ class DocumentModel(Model):
     document_hash = StringType()
     template_id = StringType()
     requester_email = StringType()
+    embedded_claim_url = StringType()
     title = StringType()
     subject = StringType()
     message = StringType()

--- a/examples/create_document.py
+++ b/examples/create_document.py
@@ -20,6 +20,10 @@ signer.name = "Jane Doe"
 signer.email = config.signer_email
 
 document.sandbox = True
+
+# To get embedded_claim_url in response, document has to be created as a draft
+# document.is_draft = True
+
 document.add_file(file)
 document.add_signer(signer)
 document.add_recipient(recipient)


### PR DESCRIPTION
Extend document model with embedded_claim_url and provide use-case example

Closes https://github.com/eversign/eversign-python-sdk/issues